### PR TITLE
 #9: Publish working responses API to npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "openai-websearch-mcp",
-  "version": "1.1.1",
+  "version": "1.2.1",
   "description": "MCP server implementation OpenAI WebSearch",
   "main": "dist/index.js",
 	"bin": {


### PR DESCRIPTION
  * Change package.json version to 1.2.1 and publish the package to npm
  
## What
#8  merged the fix for the Responses API to work but it has not been deployed to [npm](https://www.npmjs.com/package/openai-websearch-mcp/v/1.1.1)

## Why
The npm package needs to work since users may choose the [npm installation](https://github.com/tiovikram/openai-websearch-mcp?tab=readme-ov-file#using-npx)

## How
Change the package version to 1.2.1 and deploy to npm